### PR TITLE
ci: run build checks on branch pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,11 @@
 name: "Build and populate cache"
 on:
-  pull_request:
+  # Branch pushes cover new branches, same-repo PR branches, and auto-update
+  # branches pushed via NUR_DEPLOY_KEY. Avoid also running pull_request here
+  # because that creates duplicate required checks.
   push:
     branches:
-      - main
-      - master
-      - 'auto-update/**'
+      - '**'
   schedule:
     # rebuild everyday at 2:51
     # TIP: Choose a random time here so not all repositories are build at once:
@@ -71,8 +71,8 @@ jobs:
           --option restrict-eval true \
           --option allow-import-from-derivation true \
           --drv-path --show-trace \
-          -I nixpkgs=$(nix-instantiate --find-file nixpkgs) \
-          -I $PWD
+          -I "nixpkgs=$(nix-instantiate --find-file nixpkgs)" \
+          -I "$PWD"
     - name: Build nix packages
       env:
         NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM: 1  # for Darwin builds


### PR DESCRIPTION
## Summary

- run the build workflow on pushes to every branch, so new branch pushes still get tested
- remove the `pull_request` trigger to avoid duplicate required checks for same-repo PR branches
- document why auto-update branches are covered by push checks from `NUR_DEPLOY_KEY`
- quote existing `nix-env` `-I` arguments so `actionlint` passes cleanly

## Verification

- `nix run nixpkgs#actionlint -- /tmp/nur-ci-dedupe-checks/.github/workflows/build.yml`
- GitHub Actions push run `25600780350` passed on this PR branch

## Notes

The auto-update workflow pushes `auto-update/<pkg>` branches via the deploy key before creating the PR, so generated update PRs still receive a build check from the branch push. The PR creation does not need to start a second `pull_request` build for the same head SHA.
