### PR TITLE
ci: simplify build concurrency group

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
     - cron:  '51 2 * * *'
 
 concurrency:
-  group: build-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- Drop the dead `head_ref ||` fallback from the concurrency group. With `pull_request:` removed in 89515d4, `github.head_ref` is always empty for `push` events, so it never selected anything.
- Drop the redundant `build-` prefix; `github.workflow` already names the workflow.
- Switch from `github.ref_name` to `github.ref` — same uniqueness, no semantic difference, just consistent with other ref fields used in workflows.

No behavior change: builds on the same branch still cancel in-progress runs as before.

## Test plan
- [ ] Push a follow-up commit to a branch and confirm an older in-progress run on the same branch is cancelled
- [ ] Confirm only one workflow run appears per push (no duplicates)