### PR TITLE
fix(llmster): avoid broken-pipe failure in update.sh

### DIFF
--- a/pkgs/llmster/update.sh
+++ b/pkgs/llmster/update.sh
@@ -8,7 +8,10 @@ cd "$(dirname "$0")"
 
 # upstream versions look like "0.0.15-2" (version-build); the nix version
 # uses "+" to match the output of `llmster --version`
-upstream="$(curl -fsSL https://lmstudio.ai/install.sh | awk -F'"' '/^APP_VERSION=/ {print $2; exit}')"
+# NB: fetch fully before parsing — piping curl into `awk ... exit` closes the
+# pipe early, so curl fails writing the rest of the body (error 23) under pipefail.
+install_sh="$(curl -fsSL https://lmstudio.ai/install.sh)"
+upstream="$(awk -F'"' '/^APP_VERSION=/ {print $2; exit}' <<<"$install_sh")"
 new_version="${upstream%-*}+${upstream##*-}"
 
 old_version="$(sed -n 's/^  version = "\(.*\)";$/\1/p' default.nix)"


### PR DESCRIPTION
## Problem

The daily `Update packages` workflow fails on the `update (llmster)` job with:

```
curl: (23) Failure writing output to destination
##[error]Process completed with exit code 23.
```

Example failed run: https://github.com/Congee/nur/actions/runs/29089079631/job/86393601379

It's **not** disk space — it's a broken-pipe race. `update.sh` had:

```bash
upstream="$(curl -fsSL https://lmstudio.ai/install.sh | awk -F'"' '/^APP_VERSION=/ {print \$2; exit}')"
```

`awk` hits `exit` as soon as it matches `APP_VERSION=` (near the top of the script) and closes the read end of the pipe. curl is still streaming the rest of the body, its next write to the closed pipe fails → curl error 23. `set -o pipefail` then fails the whole job. It's timing/buffer dependent, which is why it fails intermittently (5 of the last 6 daily runs).

## Fix

Fetch `install.sh` fully into a variable, then parse it — command-substitution drains to EOF, so curl never writes into a closed pipe.

## Verification

Ran the fixed extraction path against the live endpoint: exits 0, extracts `0.0.19+2`, no error 23. `shellcheck` clean.