### PR TITLE
fix(rsql): patch vendored ethnum 1.5.2 -> 1.5.3 for rustc 1.96

### DIFF
--- a/pkgs/rsql/default.nix
+++ b/pkgs/rsql/default.nix
@@ -23,7 +23,11 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-sOppcQzXTfTXbQW6klwgAAw820Iq22hR1ldQ6lv6+/Q=";
   };
 
-  cargoHash = "sha256-YeJKAER+sr28FbR4xPHNbRoC2vDa8NZMzs+klfFjs6Q=";
+  # ethnum <1.5.3 uses mem::transmute(()) -> TryFromIntError, which no longer
+  # compiles now that TryFromIntError is non-zero-sized. Bump the pinned dep.
+  cargoPatches = [ ./ethnum.patch ];
+
+  cargoHash = "sha256-Wzbbyy+AN4ecILuqDdc7XtExRMNbv0pu5oqR8XTD4Vo=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/rsql/ethnum.patch
+++ b/pkgs/rsql/ethnum.patch
@@ -1,0 +1,14 @@
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -3402,9 +3402,9 @@
+
+ [[package]]
+ name = "ethnum"
+-version = "1.5.2"
++version = "1.5.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
++checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
+
+ [[package]]
+ name = "event-listener"


### PR DESCRIPTION
## Problem

Every CI build on `master` fails compiling `rsql` on the current `nixos-unstable`:

```
error[E0512]: cannot transmute between types of different sizes
  --> ethnum-1.5.2/src/error.rs:16:14
16 |     unsafe { mem::transmute(()) }   // () = 0 bits, TryFromIntError = 8 bits
```

`ethnum <=1.5.2` fabricates a `TryFromIntError` via `mem::transmute(())`, relying on the type being zero-sized. rustc 1.96 gave it a field, so the transmute is now a size mismatch. `ethnum 1.5.3` replaces the hack with `u8::try_from(-1i8).unwrap_err()`.

This surfaced only after the `nixos-unstable` channel crossed the rustc bump — PR checks were green because cachix still had the old `rsql` drv (`nix-build-uncached` skipped it); once the channel moved, the drv hash changed, cache-missed, and the compile actually ran.

## Fix

`rsql 0.19.4` is already the latest release, so bump the transitive dep via a `Cargo.lock` patch (`ethnum.patch`) and refresh `cargoHash`.

Verified locally on aarch64-darwin: `nix build .#rsql` succeeds, `rsql --version` -> `rsql/0.19.4`. This PR's own CI is a real cache-miss build (drv hash changed), so it validates x86_64-linux too.