### PR TITLE
ci: pin nixpkgs to flake.lock and add a nixpkgs bump bot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,10 +39,6 @@ jobs:
         # https://github.com/<your_githubname>/nur-packages/settings/secrets
         cachixName:
           - congee
-        nixPath:
-          - nixpkgs=channel:nixos-unstable
-          # - nixpkgs=channel:nixos-unstable
-          # - nixpkgs=channel:nixos-21.11
         # macos-latest is Apple Silicon (aarch64-darwin); free for public
         # repos and covers darwin-only packages like rapid-mlx
         os:
@@ -55,7 +51,6 @@ jobs:
     - name: Install nix
       uses: cachix/install-nix-action@v31
       with:
-        nix_path: "${{ matrix.nixPath }}"
         extra_nix_config: |
           experimental-features = nix-command flakes
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
@@ -73,6 +68,18 @@ jobs:
         done
         echo "nix daemon never became ready" >&2
         exit 1
+    - name: Pin NIX_PATH to flake.lock nixpkgs
+      # CI must build against the exact nixpkgs in flake.lock, not a live
+      # channel. A live channel drifts underneath CI between runs, so a
+      # toolchain change (e.g. rustc) breaks unrelated builds on a scheduled
+      # run instead of on the PR that caused it. nixpkgs is bumped deliberately
+      # via the auto-update/nixpkgs bot in update.yml, whose PR is then built
+      # here against the new pin.
+      run: |
+        nixpkgs=$(nix eval --impure --raw \
+          --expr '(builtins.getFlake (toString ./.)).inputs.nixpkgs.outPath')
+        echo "Pinned nixpkgs: $nixpkgs"
+        echo "NIX_PATH=nixpkgs=$nixpkgs" >> "$GITHUB_ENV"
     - name: Show nixpkgs version
       run: nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
     - name: Compute unfree push filter

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           packages=$(nix-instantiate --eval --json -E \
             'builtins.filter (n: !builtins.elem n ["lib" "modules" "overlays"]) (builtins.attrNames (import ./default.nix {}))')
-          echo "packages=$packages" >> $GITHUB_OUTPUT
+          echo "packages=$packages" >> "$GITHUB_OUTPUT"
 
   update:
     needs: detect-packages
@@ -97,3 +97,56 @@ jobs:
             --head "$branch" || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Bump the pinned nixpkgs (flake.lock) on the same daily cadence. The Build
+  # workflow pins to flake.lock, so nixpkgs only moves through this PR — and
+  # that PR is built against the new pin, surfacing toolchain breakage before
+  # merge instead of on a later scheduled run. Skipped when dispatched for a
+  # single package.
+  update-nixpkgs:
+    if: ${{ !inputs.package }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ssh-key: ${{ secrets.NUR_DEPLOY_KEY }}
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Configure git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+      - name: Update flake.lock (nixpkgs)
+        run: |
+          old=$(jq -r '.nodes.nixpkgs.locked.rev' flake.lock)
+          nix flake update nixpkgs
+          new=$(jq -r '.nodes.nixpkgs.locked.rev' flake.lock)
+          if [ "$old" = "$new" ]; then
+            echo "nixpkgs already up to date ($old)"
+            exit 0
+          fi
+          echo "OLD=$old" >> "$GITHUB_ENV"
+          echo "NEW=$new" >> "$GITHUB_ENV"
+          git commit -am "chore(flake): bump nixpkgs ${old:0:12} -> ${new:0:12}"
+      - name: Create PR
+        if: env.NEW != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          branch="auto-update/nixpkgs"
+          git fetch origin "refs/heads/$branch:refs/remotes/origin/$branch" || true
+          git checkout -B "$branch"
+          if git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+            remote_sha=$(git rev-parse "refs/remotes/origin/$branch")
+            git push -u origin "$branch" --force-with-lease="refs/heads/$branch:$remote_sha"
+          else
+            git push -u origin "$branch"
+          fi
+          gh pr create \
+            --title "chore(flake): bump nixpkgs ${OLD:0:12} -> ${NEW:0:12}" \
+            --body "Automated nixpkgs bump. Build runs on this branch against the new pin, so toolchain breakage surfaces here rather than on a later scheduled run." \
+            --base master \
+            --head "$branch" || true

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -21,7 +21,18 @@ jobs:
       - uses: actions/checkout@v7
       - uses: cachix/install-nix-action@v31
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Pin NIX_PATH to flake.lock nixpkgs
+        # Bump PRs must be generated and verified against the exact nixpkgs the
+        # Build check uses, not a live channel. Otherwise nix-update computes
+        # hashes / builds against a different nixpkgs than Build, so a bump can
+        # pass here yet fail the required check (or commit a hash Build rejects).
+        run: |
+          nixpkgs=$(nix eval --impure --raw \
+            --expr '(builtins.getFlake (toString ./.)).inputs.nixpkgs.outPath')
+          echo "NIX_PATH=nixpkgs=$nixpkgs" >> "$GITHUB_ENV"
       - id: list
         run: |
           packages=$(nix-instantiate --eval --json -E \
@@ -43,10 +54,17 @@ jobs:
       - uses: cachix/install-nix-action@v31
         if: ${{ !inputs.package || inputs.package == matrix.package }}
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Pin NIX_PATH to flake.lock nixpkgs
+        if: ${{ !inputs.package || inputs.package == matrix.package }}
+        # nix-update bumps and builds against <nixpkgs>; pin it to flake.lock so
+        # the bump is verified against the same nixpkgs the Build check uses.
+        run: |
+          nixpkgs=$(nix eval --impure --raw \
+            --expr '(builtins.getFlake (toString ./.)).inputs.nixpkgs.outPath')
+          echo "NIX_PATH=nixpkgs=$nixpkgs" >> "$GITHUB_ENV"
       - uses: cachix/cachix-action@v17
         if: ${{ !inputs.package || inputs.package == matrix.package }}
         with:

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780749050,
-        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Why

CI built against a **live channel** (`nixpkgs=channel:nixos-unstable`), decoupled from `flake.lock`. That channel drifts underneath CI between runs, so a toolchain bump (rustc, Python) breaks unrelated packages on a *scheduled* run instead of on the PR that caused it. This is exactly how the rsql/rustc-1.96 break (#128) slipped through, and how mlx-bin's cp314 assert stayed green while `flake.lock` still shipped Python 3.13.

## What

- **`build.yml`**: pin `NIX_PATH` to the `flake.lock` nixpkgs via `builtins.getFlake`, and drop the live-channel matrix. CI is now pure — it builds the exact nixpkgs the repo commits.
- **`update.yml`**: add an `update-nixpkgs` job (same daily cadence) that runs `nix flake update nixpkgs` and opens an `auto-update/nixpkgs` PR. nixpkgs now moves **only** through a reviewable PR, and that PR is built against the new pin — so toolchain breakage surfaces before merge. Also **pin the `detect-packages` and `update` jobs to `flake.lock`** (dropping `nixpkgs=channel:nixos-unstable`), so `nix-update` generates and verifies bumps against the same nixpkgs the Build check uses — not a drifting channel. `update-nixpkgs` stays unpinned; its job is to move the pin.
- **`flake.lock`**: initial bump `a799d3e3886d → e2587caef70c` (2026-06-06 → 2026-07-23) to make the pin current. This brings default `python3` 3.13 → **3.14** (satisfies mlx-bin's cp314 assert) and rustc 1.95 → **1.97** (needs the ethnum patch from #128).

## Dependency

Requires **#128** (rsql ethnum patch), now **merged** — without it, the rustc-1.97 pin fails to compile rsql. This branch is rebased on top of that merge.

## Effect

From here on, every nixpkgs/toolchain move lands as an `auto-update/nixpkgs` PR that is built against the new pin before merge — no more silent drift breaking scheduled builds.
